### PR TITLE
소셜 로그인 REST로 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,8 +28,6 @@ x86/
 bld/
 [Bb]in/
 [Oo]bj/
-[Ll]og/
-[Ll]ogs/
 
 # Visual Studio 2015/2017 cache/options directory
 .vs/

--- a/backend/accounts/urls.py
+++ b/backend/accounts/urls.py
@@ -2,6 +2,12 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
+    path('google/login/', views.GoogleLoginView.as_view(), name='google_login'),
+    path('google/callback/', views.GoogleCallbackView.as_view(),
+         name='google_callback'),
+    path('google/login/finish/', views.GoogleLogin.as_view(),
+         name='google_login_to_django'),
+
     path('kakao/login/', views.KakaoLoginView.as_view(), name='kakao_login'),
     path('kakao/callback/', views.KakaoCallbackView.as_view(), name='kakao_callback'),
     path('kakao/login/finish/', views.KakaoLoginToDjango.as_view(),

--- a/backend/accounts/urls.py
+++ b/backend/accounts/urls.py
@@ -5,7 +5,7 @@ urlpatterns = [
     path('google/login/', views.GoogleLoginView.as_view(), name='google_login'),
     path('google/callback/', views.GoogleCallbackView.as_view(),
          name='google_callback'),
-    path('google/login/finish/', views.GoogleLogin.as_view(),
+    path('google/login/finish/', views.GoogleLoginToDjango.as_view(),
          name='google_login_to_django'),
 
     path('kakao/login/', views.KakaoLoginView.as_view(), name='kakao_login'),

--- a/backend/accounts/views.py
+++ b/backend/accounts/views.py
@@ -1,9 +1,11 @@
+from json.decoder import JSONDecodeError
 from config.settings import DEBUG
 from typing import Optional
 from django.contrib.auth.models import User
 from allauth.socialaccount.models import SocialAccount
 from dj_rest_auth.registration.views import SocialLoginView
 from allauth.socialaccount.providers.kakao import views as kakao_view
+from allauth.socialaccount.providers.google import views as google_view
 from allauth.socialaccount.providers.oauth2.client import OAuth2Client
 from rest_framework.views import APIView
 from django.http import JsonResponse
@@ -19,14 +21,117 @@ from drf_yasg.utils import swagger_auto_schema
 
 
 class Constants:
-    KAKAO_CALLBACK_URI: str = get_secret('KAKAO_CALLBACK_URI')
-    REST_API_KEY: str = get_secret('KAKAO_REST_API_KEY')
     BASE_URL: str = get_secret('BASE_URL')
+    KAKAO_CALLBACK_URI: str = f"{BASE_URL}accounts/kakao/callback/"
+    GOOGLE_CALLBACK_URI: str = f"{BASE_URL}accounts/google/callback/"
+    REST_API_KEY: str = get_secret('KAKAO_REST_API_KEY')
+    GOOGLE_CLIENT_ID = get_secret("GOOGLE_CLIENT_ID")
+    GOOGLE_CLIENT_SECRET: str = get_secret("GOOGLE_CLIENT_SECRET")
+
+    # google OAuth2 요청시 사용되는 임의의 문자열
+    GOOGLE_STATE: str = get_secret("GOOGLE_STATE")
+    GOOGLE_SCOPE: str = "https://www.googleapis.com/auth/userinfo.email"
+
+
+class GoogleLoginView(APIView):
+    @swagger_auto_schema(operation_id="구글 로그인")
+    def get(self, request):
+        return redirect(f"https://accounts.google.com/o/oauth2/v2/auth?client_id={Constants.GOOGLE_CLIENT_ID}&response_type=code&redirect_uri={Constants.GOOGLE_CALLBACK_URI}&scope={Constants.GOOGLE_SCOPE}")
 
 
 # original code from @Chanjongp (https://github.com/Chanjongp/Django_Social_Login)
 # https://medium.com/chanjongs-programming-diary/django-rest-framework%EB%A1%9C-%EC%86%8C%EC%85%9C-%EB%A1%9C%EA%B7%B8%EC%9D%B8-api-%EA%B5%AC%ED%98%84%ED%95%B4%EB%B3%B4%EA%B8%B0-google-kakao-github-2ccc4d49a781
 # 로그인 성공 시, Callback 함수로 Code 값 전달받음
+class GoogleCallbackView(APIView):
+    @swagger_auto_schema(operation_id="구글 로그인 콜백")
+    def get(self, request):
+        GOOGLE_CLIENT_ID = Constants.GOOGLE_CLIENT_ID
+        GOOGLE_CLIENT_SECRET = Constants.GOOGLE_CLIENT_SECRET
+        GOOGLE_CALLBACK_URI = Constants.GOOGLE_CALLBACK_URI
+        GOOGLE_STATE = Constants.GOOGLE_STATE
+
+        code = request.GET.get('code')
+        """
+        Access Token Request
+        """
+        token_req = requests.post(
+            f"https://oauth2.googleapis.com/token?client_id={GOOGLE_CLIENT_ID}&client_secret={GOOGLE_CLIENT_SECRET}&code={code}&grant_type=authorization_code&redirect_uri={GOOGLE_CALLBACK_URI}&state={GOOGLE_STATE}")
+        token_req_json = token_req.json()
+        error = token_req_json.get("error")
+        if error is not None:
+            raise JSONDecodeError(error)
+        access_token = token_req_json.get('access_token')
+        """
+        Email Request
+        """
+        email_req = requests.get(
+            f"https://www.googleapis.com/oauth2/v1/tokeninfo?access_token={access_token}")
+        email_req_status = email_req.status_code
+        if email_req_status != 200:
+            return JsonResponse({'err_msg': 'failed to get email'}, status=status.HTTP_400_BAD_REQUEST)
+        email_req_json = email_req.json()
+        email = email_req_json.get('email')
+        """
+        Signup or Signin Request
+        """
+        is_sign_in = False
+        try:
+            user: User = User.objects.get(email=email)
+            # 기존에 가입된 유저의 Provider가 google이 아니면 에러 발생, 맞으면 로그인
+            # 다른 SNS로 가입된 유저
+            social_user: Optional[SocialAccount] = SocialAccount.objects.get(
+                user=user)
+            if social_user is None:
+                return JsonResponse({'err_msg': 'email exists but not social user'}, status=status.HTTP_400_BAD_REQUEST)
+            if social_user.provider != 'google':
+                return JsonResponse({'err_msg': 'no matching social type'}, status=status.HTTP_400_BAD_REQUEST)
+            is_sign_in = True
+        except User.DoesNotExist:
+            is_sign_in = False
+        # 로그인 / 가입 로직
+        data = {'access_token': access_token, 'code': code}
+        accept = requests.post(
+            Constants.GOOGLE_CALLBACK_URI, data=data)
+        accept_status = accept.status_code
+        sign_type = 'signin' if is_sign_in else 'signup'
+        if accept_status != 200:
+            return JsonResponse({'err_msg': f'failed to {sign_type}'}, status=accept_status)
+
+        # accept의 Response body는 DRF 미들웨어 authtoken 값을 담고 있다.
+        # DB에 자동으로 저장되는 변수이고, Request에서 Authorization 헤더에 Token으로 보내면 되는 값임.
+        # 다만 'key' 라는 키값은 이해하기 힘드므로 access_token으로 이름을 변경함.
+        accept_json = accept.json()
+        permanent_token = accept_json.get('key')
+
+        # profile 값 찾기
+
+        token_object: Token = Token.objects.get(key=permanent_token)
+
+        if not is_sign_in:
+            # 회원가입 되었으므로 다시 Find
+            user: User = token_object.user
+            social_user: SocialAccount = SocialAccount.objects.get(user=user)
+
+        profiles = Profile.objects.filter(user=user)
+
+        if not profiles:
+            username = social_user.extra_data.get(
+                'properties', {}).get('nickname', '')
+            Profile.objects.create(name=username, user=user)
+            profiles = Profile.objects.filter(user=user)
+
+        profile = profiles.get()
+        profile = ProfileSerializer(profile).data
+
+        return JsonResponse({'access_token': permanent_token, 'profile': profile})
+
+
+class GoogleLogin(SocialLoginView):
+    adapter_class = google_view.GoogleOAuth2Adapter
+    callback_url = Constants.GOOGLE_CALLBACK_URI
+    client_class = OAuth2Client
+
+
 class KakaoLoginView(APIView):
     @swagger_auto_schema(operation_id="카카오 로그인")
     def get(self, request):
@@ -118,7 +223,7 @@ class KakaoCallbackView(APIView):
 
         profiles = Profile.objects.filter(user=user)
 
-        if not profiles.exists():
+        if not profiles:
             username = social_user.extra_data.get(
                 'properties', {}).get('nickname', '')
             Profile.objects.create(name=username, user=user)

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -79,6 +79,7 @@ INSTALLED_APPS = [
     'corsheaders',
 ]
 
+
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
@@ -120,7 +121,7 @@ LOGGING = {
         "file": {
             "level": "DEBUG",
             "class": "logging.FileHandler",
-            "filename": f"./logs/{log_filename}.log",
+            "filename": BASE_DIR / f"logs/{log_filename}.log",
         },
     },
     "loggers": {
@@ -154,6 +155,11 @@ DATABASES = {
     }
 }
 
+AUTHENTICATION_BACKENDS = [
+    "django.contrib.auth.backends.ModelBackend",
+    "allauth.account.auth_backends.AuthenticationBackend",
+]
+
 SOCIALACCOUNT_PROVIDERS = {
     'kakao': {
         'APP': {
@@ -161,7 +167,12 @@ SOCIALACCOUNT_PROVIDERS = {
         }
     },
     'google': {
+        "APP": {
+            "client_id": get_secret("GOOGLE_CLIENT_ID"),
+            "secret": get_secret("GOOGLE_CLIENT_SECRET"),
+        },
         'SCOPE': [
+            'profile',
             'email',
         ],
         'AUTH_PARAMS': {

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -120,7 +120,7 @@ LOGGING = {
         "file": {
             "level": "DEBUG",
             "class": "logging.FileHandler",
-            "filename": "./logs/django.log",
+            "filename": f"./logs/{log_filename}.log",
         },
     },
     "loggers": {

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -58,6 +58,8 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
 
+    'rest_framework',
+    'rest_framework_simplejwt.token_blacklist',
     'rest_framework.authtoken',
 
     'config',
@@ -70,6 +72,7 @@ INSTALLED_APPS = [
     'dj_rest_auth.registration',
 
     'allauth.socialaccount.providers.google',
+    'allauth.socialaccount.providers.kakao',
 
     'drf_yasg',
 
@@ -106,18 +109,64 @@ TEMPLATES = [
 
 WSGI_APPLICATION = 'config.wsgi.application'
 
+IS_DOCKER = os.environ.get('IS_DOCKER')
+
+log_filename = "django" if IS_DOCKER else "django.debug"
+
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "handlers": {
+        "file": {
+            "level": "DEBUG",
+            "class": "logging.FileHandler",
+            "filename": "./logs/django.log",
+        },
+    },
+    "loggers": {
+        "django": {
+            "handlers": ["file"],
+            "level": "DEBUG",
+            "propagate": True,
+        },
+    },
+}
+
 
 # Database
 # https://docs.djangoproject.com/en/3.2/ref/settings/#databases
 
+USE_POSTGRES = os.environ.get('USE_POSTGRES')
+
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'ENGINE': 'django.db.backends.postgresql',
         'NAME': 'deepmush',
         'USER': 'deepmush',
         'PASSWORD': 'deepmush',
         'HOST': 'database',
-        'PORT': '5432',
+        'PORT': 5432,
+    }
+} if USE_POSTGRES else {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': DB_DIR / 'db.sqlite3',
+    }
+}
+
+SOCIALACCOUNT_PROVIDERS = {
+    'kakao': {
+        'APP': {
+            'key': get_secret('KAKAO_REST_API_KEY')
+        }
+    },
+    'google': {
+        'SCOPE': [
+            'email',
+        ],
+        'AUTH_PARAMS': {
+            'access_type': 'online',
+        }
     }
 }
 

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -43,6 +43,5 @@ urlpatterns = [
     path('redoc/', schema_view.with_ui('redoc',
                                        cache_timeout=0), name='schema-redoc'),
     path('admin/', admin.site.urls),
-    path("accounts/", include("allauth.urls")),
     path('accounts/', include('accounts.urls'))
 ] + staticfiles_urlpatterns()

--- a/backend/logs/.gitignore
+++ b/backend/logs/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/backend/run.sh
+++ b/backend/run.sh
@@ -3,7 +3,7 @@
 pip3 install -r requirements.txt
 
 python3 manage.py makemigrations
-python3 manage.py migrate
+python3 manage.py migrate --run-syncdb
 
 echo Starting Uvicorn.
 

--- a/backend/secrets.template.json
+++ b/backend/secrets.template.json
@@ -5,6 +5,5 @@
     "KAKAO_CALLBACK_URI": "",
     "GOOGLE_CLIENT_ID": "",
     "GOOGLE_CLIENT_SECRET": "",
-    "GOOGLE_SCOPE": "",
     "DEBUG": true
 }

--- a/backend/secrets.template.json
+++ b/backend/secrets.template.json
@@ -3,5 +3,8 @@
     "KAKAO_REST_API_KEY": "",
     "BASE_URL": "",
     "KAKAO_CALLBACK_URI": "",
+    "GOOGLE_CLIENT_ID": "",
+    "GOOGLE_CLIENT_SECRET": "",
+    "GOOGLE_SCOPE": "",
     "DEBUG": true
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ services:
       - "5432"
     volumes:
       - ./db:/var/lib/postgresql/data
+    networks:
+      - db-tier
     environment:
       - POSTGRES_USER=deepmush
       - POSTGRES_PASSWORD=deepmush
@@ -20,6 +22,11 @@ services:
       - "8000:8000"
     volumes:
       - ./backend:/backend
+    environment:
+      - USE_POSTGRES=1
+      - IS_DOCKER=1
+    networks:
+      - db-tier
     deploy:
       resources:
         limits:
@@ -29,3 +36,7 @@ services:
           cpus: "0.5"
           memory: 512M
     tty: true
+
+networks:
+  db-tier:
+    driver: bridge


### PR DESCRIPTION
* 카카오 소셜 로그인 관련 문제 수정
* 구글 소셜 로그인 커스텀 뷰로 변경해서 템플릿 엔진 제거
* 구글 소셜 로그인 시 프로필 생성 및 토큰 리스폰스로 전달하도록 변경

## 레퍼런스
* https://github.com/HackSoftware/Django-React-GoogleOauth2-Example/blob/main/server/auth/services.py
* https://www.hacksoft.io/blog/google-oauth2-with-django-react-part-2
* https://medium.com/chanjongs-programming-diary/django-rest-framework%EB%A1%9C-%EC%86%8C%EC%85%9C-%EB%A1%9C%EA%B7%B8%EC%9D%B8-api-%EA%B5%AC%ED%98%84%ED%95%B4%EB%B3%B4%EA%B8%B0-google-kakao-github-2ccc4d49a781
* https://github.com/Join2Gather/WeMeet/blob/develop/backend/accounts/views.py