### PR TITLE
Google 소셜 로그인 엔드포인트가 작동하지 않는 문제 해결

### DIFF
--- a/backend/accounts/views.py
+++ b/backend/accounts/views.py
@@ -70,6 +70,9 @@ class GoogleCallbackView(APIView):
         token_req_json = token_req.json()
         error = token_req_json.get("error")
         if error is not None:
+            if token_req_json.get('error') == 'invalid_request':
+                # callback API로 만료됐거나 잘못된 파라미터를 전달할 경우 다시 로그인
+                return redirect(f"{BASE_URL}accounts/google/login")
             return JsonResponse(token_req_json)
         access_token = token_req_json.get('access_token')
         """

--- a/backend/run.sh
+++ b/backend/run.sh
@@ -3,9 +3,8 @@
 pip3 install -r requirements.txt
 
 python3 manage.py makemigrations
-python3 manage.py migrate auth --run-syncdb
 python3 manage.py migrate --run-syncdb
 
 echo Starting Uvicorn.
 
-uvicorn config.asgi:application --host 0.0.0.0 --workers 10 --reload
+gunicorn config.wsgi:application --bind=0.0.0.0:8000 -w 8 --threads 8 -k gthread --reload


### PR DESCRIPTION
### tl;dr
uvicorn 워커를 늘리고 --limit-concurrency값을 증가시켜도 reload 플래그가 켜져있다면 단일 프로세스로 동작함.
따라서 view에서 finish view를 호출하는 구글 로그인 API는 싱글 프로세스 / 싱글 스레드가 최대 한번에 하나의 request밖에 처리하지 못해서 타임아웃이 생김.

### 참조 문서
[uvicorn docs](https://www.uvicorn.org/)

```
--workers INTEGER               Number of worker processes. Defaults to the
                                $WEB_CONCURRENCY environment variable if
                                available, or 1. Not valid with --reload.
```


### 해결 방안
uvicorn은 구조상의 문제가 있다고 생각하여 WSGI / gunicorn 환경으로 마이그레이션하였음.
gthread worker class로 선택 후 8 threads per process / 8 process로 설정함.

sqlite 로컬 환경에서 실행시 속도 문제가 있었지만 docker / postgres상에서는 안정적으로 동작함.
