### PR TITLE
GPU Passthrough를 통한 worker 성능 향상

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -27,6 +27,7 @@ RUN pip install psycopg2-binary --no-binary psycopg2-binary
 RUN pip install -r requirements.txt --no-cache-dir
 
 RUN pip install torch==1.10.1+cu113 -f https://download.pytorch.org/whl/cu113/torch_stable.html
+RUN pip install torchvision==0.11.2+cu113 -f https://download.pytorch.org/whl/cu113/torch_stable.html
 
 COPY registry.py /usr/local/lib/python3.9/site-packages/django/apps/
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -16,6 +16,8 @@ RUN mkdir -p ~/.pip && echo "[global]\n\
     index-url=http://mirror.kakao.com/pypi/simple\n\
     trusted-host=mirror.kakao.com" > ~/.pip/pip.conf
 
+RUN mkdir -p /root/.cache/torch/hub && wget https://github.com/ultralytics/yolov5/archive/master.zip -P /root/.cache/torch/hub
+
 RUN pip install --upgrade pip
 
 COPY requirements.txt ./
@@ -23,6 +25,8 @@ COPY requirements.txt ./
 RUN pip install psycopg2-binary --no-binary psycopg2-binary
 
 RUN pip install -r requirements.txt --no-cache-dir
+
+RUN pip install torch==1.10.1+cu113 -f https://download.pytorch.org/whl/cu113/torch_stable.html
 
 COPY registry.py /usr/local/lib/python3.9/site-packages/django/apps/
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -26,8 +26,8 @@ RUN pip install psycopg2-binary --no-binary psycopg2-binary
 
 RUN pip install -r requirements.txt --no-cache-dir
 
-RUN pip install torch==1.10.1+cu113 -f https://download.pytorch.org/whl/cu113/torch_stable.html
-RUN pip install torchvision==0.11.2+cu113 -f https://download.pytorch.org/whl/cu113/torch_stable.html
+RUN pip install torch==1.10.1+cu113 -f https://download.pytorch.org/whl/cu113/torch_stable.html ; exit 0
+RUN pip install torchvision==0.11.2+cu113 -f https://download.pytorch.org/whl/cu113/torch_stable.html ; exit 0
 
 COPY registry.py /usr/local/lib/python3.9/site-packages/django/apps/
 

--- a/backend/inference/lib/expect.py
+++ b/backend/inference/lib/expect.py
@@ -5,26 +5,17 @@ import torch
 import requests
 from tempfile import NamedTemporaryFile
 from uuid import uuid4
+from glob import glob
 
 torch.hub._validate_not_a_forked_repo = lambda a, b, c: True
 
 
 def expect_image(image: str):
     """get bounding boxes"""
-    res = requests.get(image)
-
-    image_file = BytesIO(res.content)
-
-    temp_file = NamedTemporaryFile()
-    temp_file.write(image_file.read())
-
-    image_rgb = PILImage.open(temp_file.name).convert('RGB')
-    np_image = np.array(image_rgb)
-
     model = torch.hub.load('ultralytics/yolov5',
-                           'custom', path='inference/lib/mushroomAI.pt', force_reload=True)
+                           'custom', path='inference/lib/mushroomAI.pt')
 
-    results = model([np_image.copy()])
+    results = model(image)
 
     results.print()
 
@@ -33,6 +24,6 @@ def expect_image(image: str):
 
     results.save(path)
 
-    path += '/image0.jpg'
+    path = glob(path + '/*')[0]
 
     return [results.pandas().xyxy[0].values.tolist(), path]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -41,8 +41,8 @@ opencv-python>=4.1.2
 # Pillow
 PyYAML==5.4.1
 # scipy>=1.4.1
-torch>=1.10.1
-torchvision>=0.11.2
+torch==1.10.1
+torchvision==0.11.2
 tqdm>=4.41.0
 tensorboard>=2.7.0
 cv

--- a/backend/run-celery.sh
+++ b/backend/run-celery.sh
@@ -8,4 +8,4 @@ python3 manage.py migrate --run-syncdb --database=mongodb
 
 echo Starting celery worker.
 
-exec celery -A config worker -l INFO -P threads -c 3
+exec celery -A config worker -l INFO -c 1

--- a/docker-compose.gpu.yml
+++ b/docker-compose.gpu.yml
@@ -1,0 +1,13 @@
+version: "3.3"
+
+services:
+  worker:
+    deploy:
+      resources:
+        reservations:
+          cpus: '2'
+          memory: 4G
+          devices:
+          - driver: nvidia
+            count: 'all'
+            capabilities: [gpu]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -133,6 +133,13 @@ services:
     environment:
       - USE_POSTGRES=1
       - IS_DOCKER=1
+    deploy:
+      resources:
+        reservations:
+          devices:
+          - driver: nvidia
+            count: 'all'
+            capabilities: [gpu]
     tty: true
   
   elk:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -136,6 +136,8 @@ services:
     deploy:
       resources:
         reservations:
+          cpus: '2'
+          memory: 4G
           devices:
           - driver: nvidia
             count: 'all'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -133,15 +133,6 @@ services:
     environment:
       - USE_POSTGRES=1
       - IS_DOCKER=1
-    deploy:
-      resources:
-        reservations:
-          cpus: '2'
-          memory: 4G
-          devices:
-          - driver: nvidia
-            count: 'all'
-            capabilities: [gpu]
     tty: true
   
   elk:

--- a/nginx/config/nginx.conf
+++ b/nginx/config/nginx.conf
@@ -13,12 +13,14 @@ upstream pgadmin_upstream {
 server {
 
     listen 8000;
+    client_max_body_size 0;
 
     location / {
         proxy_pass http://backend_upstream;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header Host $host:$server_port;
         proxy_redirect off;
+        proxy_read_timeout 3600;
 
         access_log /var/log/nginx/backend-access.log;
         error_log /var/log/nginx/backend-error.log;
@@ -29,12 +31,14 @@ server {
 server {
 
     listen 8001;
+    client_max_body_size 0;
 
     location / {
         proxy_pass http://mongo_express_upstream;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header Host $host:$server_port;
         proxy_redirect off;
+        proxy_read_timeout 3600;
 
         access_log /var/log/nginx/mongo-express-access.log;
         error_log /var/log/nginx/mongo-express-error.log;
@@ -45,12 +49,14 @@ server {
 server {
 
     listen 8002;
+    client_max_body_size 0;
 
     location / {
         proxy_pass http://pgadmin_upstream;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header Host $host:$server_port;
         proxy_redirect off;
+        proxy_read_timeout 3600;
 
         access_log /var/log/nginx/pgadmin-access.log;
         error_log /var/log/nginx/pgadmin-error.log;


### PR DESCRIPTION
### tl;dr
Docker-compose GPU Passthrough를 통해 머신의 Nvidia GPU를 worker에 할당하여 추론 성능을 향상

wsl2 기준으로 작동하는 것을 확인
RTX 3080 기준 동기적으로 리스폰스까지 4초가 걸림 (모델 다운로드 시간 미포함)

### DONE
* nginx body size와 timeout 관련 오류 수정
* torch / torchvision 버전을 cuda 11.3으로 변경
* celery 워커 갯수를 1개로 줄임
* celery 워커에 CPU 2 / Memory 4G 할당
* Nvidia GPU를 지원하지 않는 머신일 경우를 감안해 docker-compose.gpu.yml 분리 및 cuda torch Dockerfile 예외 처리 추가
